### PR TITLE
Allow to reverse the unix timestamp back.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 
+use chrono::{DateTime, TimeZone, Utc};
+
 #[macro_use]
 extern crate clap;
 
@@ -11,17 +13,35 @@ fn main() {
         .version(crate_version!())
         .arg(clap::Arg::with_name("millis").long("millis").short("m"))
         .arg(clap::Arg::with_name("nanos").long("nanos").short("n"))
-        .group(clap::ArgGroup::with_name("exclusions").arg("millis").arg("nanos"))
+        .arg(clap::Arg::with_name("timestamp").index(1))
+        .group(
+            clap::ArgGroup::with_name("exclusions")
+                .arg("millis")
+                .arg("nanos"),
+        )
         .get_matches();
 
-    let timestamp = chrono::Utc::now();
-    let time_str = if matches.is_present("millis") {
-        timestamp.timestamp_millis()
-    } else if matches.is_present("nanos") {
-        timestamp.timestamp_nanos()
-    } else {
-        timestamp.timestamp()
-    };
+    if matches.is_present("timestamp") {
+        let timestamp: i64 = matches.value_of("timestamp").unwrap().parse().unwrap();
+        let dt: DateTime<Utc> = if matches.is_present("millis") {
+            Utc.timestamp_millis(timestamp)
+        } else if matches.is_present("nanos") {
+            Utc.timestamp_nanos(timestamp)
+        } else {
+            Utc.timestamp(timestamp, 0)
+        };
 
-    println!("{}", time_str);
+        println!("{}", dt.to_rfc2822());
+    } else {
+        let timestamp = chrono::Utc::now();
+        let time_str = if matches.is_present("millis") {
+            timestamp.timestamp_millis()
+        } else if matches.is_present("nanos") {
+            timestamp.timestamp_nanos()
+        } else {
+            timestamp.timestamp()
+        };
+
+        println!("{}", time_str);
+    }
 }


### PR DESCRIPTION
By passing a unix timestamp to the `unixtime` command it shows an RFC 2822 date.

Resolves: #3